### PR TITLE
Added constructor so object initialize correctly on Windows. Fixed ou…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -203,6 +203,12 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
         if (mask & (1ull << DecorationBinding))
             fprintf(stderr, " (Binding : %u)", compiler.get_decoration(res.id, DecorationBinding));
         fprintf(stderr, "\n");
+
+		if((! is_push_constant) && is_block) {
+			for(uint32_t index = 0; index < compiler.get_member_count(res.type_id); ++index) {
+				fprintf(stderr, "    %u: %s (%u)\n", index, compiler.get_member_name(res.type_id, index).c_str(), compiler.get_member_decoration(res.type_id, index, DecorationOffset));
+			}
+		}
     }
     fprintf(stderr, "=============\n\n");
 }

--- a/spir2cross.cpp
+++ b/spir2cross.cpp
@@ -622,6 +622,12 @@ void Compiler::set_member_name(uint32_t id, uint32_t index, const std::string& n
     meta.at(id).members[index].alias = name;
 }
 
+uint32_t Compiler::get_member_count(uint32_t id) const
+{
+    auto &m = meta.at(id);
+	return static_cast<uint32_t>(m.members.size());
+}
+
 const std::string& Compiler::get_member_name(uint32_t id, uint32_t index) const
 {
     auto &m = meta.at(id);

--- a/spir2cross.hpp
+++ b/spir2cross.hpp
@@ -122,6 +122,8 @@ namespace spir2cross
                 return join("_", id);
             }
 
+			uint32_t get_member_count(uint32_t id) const;
+
             // Given an OpTypeStruct in ID, obtain the identifier for member number "index".
             // This may be an empty string.
             const std::string& get_member_name(uint32_t id, uint32_t index) const;

--- a/spir2cross.hpp
+++ b/spir2cross.hpp
@@ -122,6 +122,8 @@ namespace spir2cross
                 return join("_", id);
             }
 
+			// Gets the member count associated with an OpTypeStruct in id, e.g. the 
+			// fields of a uniform block.
 			uint32_t get_member_count(uint32_t id) const;
 
             // Given an OpTypeStruct in ID, obtain the identifier for member number "index".

--- a/spir2cross.hpp
+++ b/spir2cross.hpp
@@ -225,7 +225,7 @@ namespace spir2cross
                     return nullptr;
             }
 
-            struct
+            struct execution
             {
                 uint64_t flags = 0;
                 spv::ExecutionModel model;
@@ -236,13 +236,15 @@ namespace spir2cross
                 } workgroup_size;
                 uint32_t invocations = 0;
                 uint32_t output_vertices = 0;
+				execution() {}
             } execution;
 
-            struct
+            struct source
             {
                 uint32_t version = 0;
                 bool es = false;
                 bool known = false;
+				source() {}
             } source;
 
             std::unordered_set<uint32_t> loop_block;

--- a/test_shaders.bash
+++ b/test_shaders.bash
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TMP_DIR=$THIS_DIR/tmp
+SHADER_DIRS=$(ls -C1 $THIS_DIR/shaders)
+REF_DIR=$THIS_DIR/reference
+REPORT_FILE=$THIS_DIR/report.txt
+
+# Compile to SPIR-V
+for dir in ${SHADER_DIRS[*]}
+do
+    src_dir=$THIS_DIR/shaders/$dir
+    src_shaders=$(ls -C1 $src_dir/*)
+
+    spirv_dir=$TMP_DIR/spirv/$dir
+    mkdir -p $spirv_dir
+
+    for src_file in ${src_shaders[*]}
+    do
+        spirv_file=$spirv_dir/`basename $src_file`.spirv
+        glslangvalidator -V -o $spirv_file $src_file
+    done
+done
+
+# Back compile to GLSL
+for dir in ${SHADER_DIRS[*]}
+do
+    src_dir=$THIS_DIR/shaders/$dir
+    src_shaders=$(ls -C1 $src_dir/*)
+
+    spirv_dir=$TMP_DIR/spirv/$dir
+
+    out_dir=$TMP_DIR/shaders/$dir
+    mkdir -p $out_dir
+
+    for src_file in ${src_shaders[*]}
+    do
+        basename=`basename $src_file`;
+        spirv_file=$spirv_dir/$basename.spirv
+        glsl_file=$out_dir/$basename
+        if [ -f "$spirv_file" ]; then
+            echo "spir2cross --output $glsl_file $spirv_file"
+            spir2cross --output $glsl_file $spirv_file
+        fi
+    done
+done
+
+echo ""
+
+# Diff report
+echo "This is a diff of the shader files that compiled succesffully to SPIR_V and back to GLSL." > $REPORT_FILE
+echo "" >> $REPORT_FILE
+
+for dir in ${SHADER_DIRS[*]}
+do
+    src_dir=$THIS_DIR/shaders/$dir
+    src_shaders=$(ls -C1 $src_dir/*)
+
+    spirv_dir=$TMP_DIR/spirv/$dir
+    out_dir=$TMP_DIR/shaders/$dir
+    ref_dir=$REF_DIR/shaders/$dir
+
+    for src_file in ${src_shaders[*]}
+    do
+        basename=`basename $src_file`;
+        spirv_file=$spirv_dir/$basename.spirv
+        glsl_file=$out_dir/$basename
+        ref_file=$ref_dir/$basename
+        if [ -f "$glsl_file" ]; then
+            echo "diff $ref_file $glsl_file"
+            echo "SOURCE FILE   : $src_file" >> $REPORT_FILE
+            echo "SPIR-V FILE   : $spirv_file" >> $REPORT_FILE
+            echo "GLSL FILE     : $glsl_file" >> $REPORT_FILE
+            echo "REF GLSL FILE : $ref_file" >> $REPORT_FILE
+            echo "diff output:" >> $REPORT_FILE
+            diff $ref_file $glsl_file >> $REPORT_FILE
+            echo "end of diff output" >> $REPORT_FILE
+            echo -e "\n" >> $REPORT_FILE
+        fi
+    done
+done
+
+echo -e "\nSee report.txt for more information!"


### PR DESCRIPTION
…t of bounds error when processing SPIR-V - this was throwing a vector out of bounds exception on some Window's (MSVC) build variations.

Added bash based tester. Changes were tested on both Linux and Windows to make sure existing functionality remained in tact.