### PR TITLE
Switching (x%y) to mod(x,y). GLSL does not support modulo operator.

### DIFF
--- a/spir2glsl.cpp
+++ b/spir2glsl.cpp
@@ -2719,7 +2719,7 @@ void CompilerGLSL::emit_instruction(const Instruction &i)
         case OpUMod:
         case OpSMod:
         case OpFMod:
-            BOP(%);
+            BFOP(mod);
             break;
 
         // Relational


### PR DESCRIPTION
My generated GLSL was failing validation because of modulo `%` operator.  I don't believe GLSL supports a  modulo  `%` operator.  I've updated the code to output the modulo function `mod` instead.